### PR TITLE
fix: ems:admin:command

### DIFF
--- a/bin/emsch-setup.sh
+++ b/bin/emsch-setup.sh
@@ -12,7 +12,7 @@ set -o allexport
 source /tmp/$_instance_name
 set +o allexport
 
-php /opt/src/bin/console \$@
+php /opt/src/bin/console "\$@"
 
 EOL
 


### PR DESCRIPTION
Fix in 5.3.0 `ems:admin:command` is not working.

```bash
 preview ems:admin:command 'ems:env:rebuild preview'
[2023-02-28T13:35:09.500863+01:00] console.CRITICAL: Error thrown while running command "ems:admin:command 'ems:env:rebuild' preview". Message: "Too many arguments to "ems:admin:command" command, expected arguments "remote-command"." {"exception":"[object] (Symfony\\Component\\Console\\Exception\\RuntimeExc
eption(code: 0): Too many arguments to \"ems:admin:command\" command, expected arguments \"remote-command\". at /opt/src/vendor/symfony/console/Input/ArgvInput.php:193)","command":"ems:admin:command 'ems:env:rebuild' preview","message":"Too many arguments to \"ems:admin:command\" command, expected arguments
 \"remote-command\"."} []

 * Duration: 0 s
 * Memory: 18 MB

[2023-02-28T13:35:09.502866+01:00] console.DEBUG: Command "ems:admin:command 'ems:env:rebuild' preview" exited with code "1" {"command":"ems:admin:command 'ems:env:rebuild' preview","code":1} []


  Too many arguments to "ems:admin:command" command, expected arguments "remote-command".  
````