### PR TITLE
fix: build for 5.22.0

### DIFF
--- a/test/configs/elasticms/demo-dev.env
+++ b/test/configs/elasticms/demo-dev.env
@@ -38,14 +38,14 @@ EMSCO_DATE_TIME_FORMAT='j/m/Y \a\t G:i'
 EMSCO_DATEPICKER_FORMAT='dd/mm/yyyy'
 EMSCO_DATEPICKER_WEEKSTART='1'
 EMSCO_DATEPICKER_DAYSOFWEEK_HIGHLIGHTED='[0,6]'
-EMSCO_ALLOW_USER_REGISTRATION='false'
-EMSCO_LOG_BY_PASS=true
 ###< Core ###
 
 ###> EMSCH ###
+EMSCH_ENV='default'
+EMSCH_ENVS='{"default":{"alias":"ems_promo_v2_preview","backend":"http://demo-admin","router": false, "default": true}}'
 EMSCH_TEMPLATE_EMS_LINK='@EMSCH/template/ems/{type}.ems_link.twig'
 EMSCH_LOCALES='["en","fr","nl","de"]'
 EMSCH_TRANSLATION_TYPE='label'
 EMSCH_ROUTE_TYPE='route'
-EMSCH_TEMPLATES='{"template":{"name":"name","code":"body"}}'
+EMSCH_TEMPLATES='{"template": {"name": "name","code": "body"},"template_ems": {"name": "name","code": "body"}}'
 ###< EMSCH ###

--- a/test/configs/elasticms/demo.env
+++ b/test/configs/elasticms/demo.env
@@ -38,14 +38,14 @@ EMSCO_DATE_TIME_FORMAT='j/m/Y \a\t G:i'
 EMSCO_DATEPICKER_FORMAT='dd/mm/yyyy'
 EMSCO_DATEPICKER_WEEKSTART='1'
 EMSCO_DATEPICKER_DAYSOFWEEK_HIGHLIGHTED='[0,6]'
-EMSCO_ALLOW_USER_REGISTRATION='false'
-EMSCO_LOG_BY_PASS=true
 ###< Core ###
 
 ###> EMSCH ###
+EMSCH_ENV='default'
+EMSCH_ENVS='{"default":{"alias":"ems_promo_v2_preview","backend":"http://demo-admin","router": false, "default": true}}'
 EMSCH_TEMPLATE_EMS_LINK='@EMSCH/template/ems/{type}.ems_link.twig'
 EMSCH_LOCALES='["en","fr","nl","de"]'
 EMSCH_TRANSLATION_TYPE='label'
 EMSCH_ROUTE_TYPE='route'
-EMSCH_TEMPLATES='{"template":{"name":"name","code":"body"}}'
+EMSCH_TEMPLATES='{"template":{"name":"name","code":"body"},"template_ems":{"name":"name","code":"body"}}'
 ###< EMSCH ###

--- a/test/configs/skeleton/zz-live.env
+++ b/test/configs/skeleton/zz-live.env
@@ -1,5 +1,5 @@
 ###> Apache ###
-SERVER_NAME='demo'
+SERVER_NAME='demo-live'
 SERVER_ALIASES='*'
 APACHE_CACHE_CONTROL='immutable, max-age=63072000, public'
 APACHE_ENVIRONMENTS='[]'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -109,10 +109,8 @@ services:
     networks:
       default:
         aliases:
-          - demo-admin
           - demo-admin-dev
-          - demo-pgsql-admin
-          - demo-pgsql-admin-dev
+          - demo-admin
     container_name: ems
     environment:
       - AWS_S3_STORAGE_BUCKET_NAME=${BATS_S3_STORAGE_BUCKET_NAME}
@@ -137,12 +135,22 @@ services:
       - JOBS_ENABLED=${BATS_JOBS_ENABLED}
       - METRICS_ENABLED=${BATS_METRICS_ENABLED}
       - CLI_PHP_MEMORY_LIMIT=512M
+    volumes:
+      - ./demo/configs/admin:/opt/src/configs/admin
+      - ./demo/configs/document:/opt/src/configs/document
     command: ["wait-for-it", "${BATS_DB_HOST}:${BATS_DB_PORT}", "--", "/usr/bin/supervisord", "-c", "/etc/supervisord/supervisord.conf"]
     mem_limit: 512m
+    ports:
+      - "8881:9000"
 
   emsch:
     image: ${BATS_DOCKER_IMAGE_NAME}
     container_name: emsch
+    networks:
+      default:
+        aliases:
+          - demo-live
+          - demo-preview-dev
     environment:
       - APP_ENV=dev
       - REDIS_HOST=${BATS_REDIS_HOST}
@@ -168,15 +176,15 @@ services:
       - METRICS_ENABLED=${BATS_METRICS_ENABLED}
       - VARNISH_ENABLED=${BATS_VARNISH_ENABLED}
     volumes:
-      - ./demo/configs/admin:/opt/src/admin
-      - ./demo/configs/document:/opt/src/document
       - ./demo/dist:/opt/src/public/skeleton:ro
       - ./demo/skeleton:/opt/src/local/ems_promo_v2_preview
       - ./demo/skeleton:/opt/src/local/ems_promo_v2_live
       - ./demo/skeleton:/opt/src/local/skeleton
     mem_limit: 512m
+    ports:
+      - "8882:9000"
 
 networks:
   default:
-    external:
-      name: docker_default
+    name: docker_default
+    external: true

--- a/test/helpers/containers.bash
+++ b/test/helpers/containers.bash
@@ -3,9 +3,9 @@
 # Removes container $1
 function container_clean {
   run ${BATS_CONTAINER_ENGINE} kill $1 &>/dev/null ||:
-  sleep .25s
+  sleep 25
   run ${BATS_CONTAINER_ENGINE} rm -vf $1 &>/dev/null ||:
-  sleep .25s
+  sleep 25
 }
 
 # get the ip of container $1
@@ -78,7 +78,7 @@ function container_wait_for_log {
   local -r container=$1
   local -ir timeout_sec=$2
   shift 2
-  retry $(( $timeout_sec * 2 )) .5s container_assert_log $container "$*"
+  retry $(( $timeout_sec * 2 )) 5 container_assert_log $container "$*"
 }
 
 # wait for a container to produce a given text in its command output
@@ -90,7 +90,7 @@ function container_wait_for_command {
   local -r cmd=$2
   local -ir timeout_sec=$3
   shift 3
-  retry $(( $timeout_sec * 2 )) .5s container_assert_command $container "$cmd" "$*"
+  retry $(( $timeout_sec * 2 )) 5 container_assert_command $container "$cmd" "$*"
 }
 
 # wait for a container healthy state
@@ -100,5 +100,5 @@ function container_wait_for_healthy {
   local -r container=$1
   local -ir timeout_sec=$2
   shift 2
-  retry $(( $timeout_sec * 2 )) .5s container_assert_healthy $container
+  retry $(( $timeout_sec * 2 )) 0.5 container_assert_healthy $container
 }

--- a/test/helpers/tests.bash
+++ b/test/helpers/tests.bash
@@ -1,7 +1,6 @@
 # Test if requirements are met
 (
 	type ${BATS_CONTAINER_ENGINE} &>/dev/null || ( echo "${BATS_CONTAINER_ENGINE} is not available"; exit 1 )
-    type ${BATS_CONTAINER_COMPOSE_ENGINE} &>/dev/null || ( echo "${BATS_CONTAINER_COMPOSE_ENGINE} is not available"; exit 1 )
 )>&2
 
 TEST_FILE=$(basename $BATS_TEST_FILENAME .bats)

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -212,259 +212,22 @@ export BATS_CONTAINER_NETWORK_NAME="${CONTAINER_NETWORK_NAME:-docker_default}"
 
 }
 
-@test "[$TEST_FILE] Login to Elasticms for configuration." {
+@test "[$TEST_FILE] Login to Elasticms for admin." {
 
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:login --username=${BATS_ELASTICMS_ADMIN_USERNAME} --password=${BATS_ELASTICMS_ADMIN_PASSWORD} ${BATS_ELASTICMS_SKELETON_BACKEND_URL}
+  run ${BATS_CONTAINER_ENGINE} exec ems ${BATS_ELASTICMS_ADMIN_ENVIRONMENT} ems:admin:login --no-debug ${BATS_ELASTICMS_SKELETON_BACKEND_URL} --username=${BATS_ELASTICMS_ADMIN_USERNAME} --password=${BATS_ELASTICMS_ADMIN_PASSWORD}
   assert_output -r ".*\[OK\] Welcome ${BATS_ELASTICMS_ADMIN_USERNAME} on ${BATS_ELASTICMS_SKELETON_BACKEND_URL}"
 
 }
 
-@test "[$TEST_FILE] Upload Elasticms assets." {
+@test "[$TEST_FILE] Restore elasticms configuration" {
 
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} emsch:local:folder-upload -- /opt/src/admin/assets
-  assert_output -r ".*\[OK\] .* \(on .*\) assets have been uploaded"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:local:upload --filename=/opt/src/local/skeleton/template/asset_hash.twig
-  assert_output -r ".*\[OK\] Assets .* have been uploaded"
+  run ${BATS_CONTAINER_ENGINE} exec ems ${BATS_ELASTICMS_ADMIN_ENVIRONMENT} ems:admin:restore --no-debug --configs --configs-folder=/opt/src/configs/admin --force
 
 }
 
-@test "[$TEST_FILE] Configure Elasticms Filters." {
+@test "[$TEST_FILE] Activate Elasticms content types." {
 
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter dutch_stemmer
-  assert_output -r "filter dutch_stemmer with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter dutch_stop
-  assert_output -r "filter dutch_stop with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter empty_elision
-  assert_output -r "filter empty_elision with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter english_stemmer
-  assert_output -r "filter english_stemmer with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter english_stop
-  assert_output -r "filter english_stop with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter french_elision
-  assert_output -r "filter french_elision with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter french_stemmer
-  assert_output -r "filter french_stemmer with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter french_stop
-  assert_output -r "filter french_stop with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter german_stemmer
-  assert_output -r "filter german_stemmer with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update filter german_stop
-  assert_output -r "filter german_stop with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms Analyzers." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update analyzer alpha_order
-  assert_output -r "analyzer alpha_order with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update analyzer dutch_for_highlighting
-  assert_output -r "analyzer dutch_for_highlighting with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update analyzer english_for_highlighting
-  assert_output -r "analyzer english_for_highlighting with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update analyzer french_for_highlighting
-  assert_output -r "analyzer french_for_highlighting with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update analyzer german_for_highlighting
-  assert_output -r "analyzer german_for_highlighting with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update analyzer html_strip
-  assert_output -r "analyzer html_strip with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms Schedules." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update schedule check-aliases
-  assert_output -r "schedule check-aliases with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update schedule clear-logs
-  assert_output -r "schedule clear-logs with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update schedule publish-releases
-  assert_output -r "schedule publish-releases with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update schedule remove-expired-submissions
-  assert_output -r "schedule remove-expired-submissions with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms Wysiwygs." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update wysiwyg-style-set bootstrap
-  assert_output -r "wysiwyg-style-set bootstrap with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update wysiwyg-style-set revealjs
-  assert_output -r "wysiwyg-style-set revealjs with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update wysiwyg-profile Full
-  assert_output -r "wysiwyg-profile Full with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update wysiwyg-profile Light
-  assert_output -r "wysiwyg-profile Light with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update wysiwyg-profile Sample
-  assert_output -r "wysiwyg-profile Sample with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update wysiwyg-profile Standard
-  assert_output -r "wysiwyg-profile Standard with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms I18N." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update i18n config
-  assert_output -r "i18n config with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update i18n ems.documentation.body
-  assert_output -r "i18n ems.documentation.body with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update i18n locale.fr
-  assert_output -r "i18n locale.fr with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update i18n locale.nl
-  assert_output -r "i18n locale.nl with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update i18n locale.de
-  assert_output -r "i18n locale.de with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update i18n locale.en
-  assert_output -r "i18n locale.en with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update i18n locales
-  assert_output -r "i18n locales with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update i18n asset.type.manual
-  assert_output -r "i18n asset.type.manual with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms Environments." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update environment default
-  assert_output -r "environment default with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update environment preview
-  assert_output -r "environment preview with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update environment live
-  assert_output -r "environment live with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms Forms." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update form add_menu_item
-  assert_output -r "form add_menu_item with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update form dashboard_default_search_options
-  assert_output -r "form dashboard_default_search_options with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update form dashboard_sitemap_options
-  assert_output -r "form dashboard_sitemap_options with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update form display
-  assert_output -r "form display with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update form label
-  assert_output -r "form label with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update form menu-locales
-  assert_output -r "form menu-locales with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update form search_fields
-  assert_output -r "form search_fields with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms ContentTypes." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type category
-  assert_output -r "content-type category with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type form_instance
-  assert_output -r "content-type form_instance with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type label
-  assert_output -r "content-type label with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type media_file
-  assert_output -r "content-type media_file with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type news
-  assert_output -r "content-type news with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type page
-  assert_output -r "content-type page with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type route
-  assert_output -r "content-type route with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type section
-  assert_output -r "content-type section with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type slideshow
-  assert_output -r "content-type slideshow with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type template
-  assert_output -r "content-type template with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type template_ems
-  assert_output -r "content-type template_ems with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update content-type user_group
-  assert_output -r "content-type user_group with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms QuerySearches." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update query-search categories
-  assert_output -r "query-search categories with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update query-search pages
-  assert_output -r "query-search pages with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update query-search documents
-  assert_output -r "query-search documents with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update query-search forms
-  assert_output -r "query-search forms with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms Dashboards." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update dashboard default-search
-  assert_output -r "dashboard default-search with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update dashboard media-library
-  assert_output -r "dashboard media-library with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update dashboard sitemap
-  assert_output -r "dashboard sitemap with id .* has been updated"
-
-}
-
-@test "[$TEST_FILE] Configure Elasticms Channels." {
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update channel preview
-  assert_output -r "channel preview with id .* has been updated"
-
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:admin:update channel live
-  assert_output -r "channel live with id .* has been updated"
+  run ${BATS_CONTAINER_ENGINE} exec ems ${BATS_ELASTICMS_ADMIN_ENVIRONMENT} ems:contenttype:activate --all --force
 
 }
 
@@ -479,18 +242,29 @@ export BATS_CONTAINER_NETWORK_NAME="${CONTAINER_NETWORK_NAME:-docker_default}"
 
 }
 
-@test "[$TEST_FILE] Activate Elasticms content types." {
+@test "[$TEST_FILE] Restore elasticms documents" {
 
-  run ${BATS_CONTAINER_ENGINE} exec ems ${BATS_ELASTICMS_ADMIN_ENVIRONMENT} ems:contenttype:activate --all --force
+  run ${BATS_CONTAINER_ENGINE} exec ems ${BATS_ELASTICMS_ADMIN_ENVIRONMENT} ems:admin:restore --no-debug --documents --documents-folder=/opt/src/configs/document --force
 
-  # Missing message when action is done (with success or not)
-  # assert_output -r ""
+}
+
+@test "[$TEST_FILE] Login to Elasticms for web." {
+
+  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} emsch:local:login ${BATS_ELASTICMS_ADMIN_USERNAME} ${BATS_ELASTICMS_ADMIN_PASSWORD}
+  assert_output -r ".*\[OK\] Welcome ${BATS_ELASTICMS_ADMIN_USERNAME} on ${BATS_ELASTICMS_SKELETON_BACKEND_URL}"
+
+}
+
+@test "[$TEST_FILE] Upload web assets." {
+
+  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} emsch:local:upload --filename=/opt/src/local/skeleton/template/asset_hash.twig
+  assert_output -r ".*\[OK\] Assets .* have been uploaded"
 
 }
 
 @test "[$TEST_FILE] Push templates, routes and translations." {
 
-  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:local:push --force
+  run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} emsch:local:push --force
 
   # Missing message when action is done (with success or not)
   # assert_output -r ""
@@ -499,16 +273,6 @@ export BATS_CONTAINER_NETWORK_NAME="${CONTAINER_NETWORK_NAME:-docker_default}"
 
 @test "[$TEST_FILE] Wait for green." {
     run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} emsch:health-check -g
-}
-
-@test "[$TEST_FILE] Upload documents." {
-
-  for type in form_instance category page section slideshow media_file news user_group; do
-    run ${BATS_CONTAINER_ENGINE} exec emsch ${BATS_ELASTICMS_SKELETON_ENVIRONMENT} ems:document:upload ${type}
-    # Missing message when action is done (with success or not)
-    # assert_output -r ""
-  done
-
 }
 
 @test "[$TEST_FILE] Align live." {


### PR DESCRIPTION
- For fixing the build the tests are now using the restore command

- ```sleep .25s``` was not working on mac converted to ```sleep 25```

- Remove the following because also not working on mac environment
```bash  
type ${BATS_CONTAINER_COMPOSE_ENGINE} &>/dev/null || ( echo "${BATS_CONTAINER_COMPOSE_ENGINE} is not available"; exit 1 ) 
```

- Added port forward for ems and emsch (easy for debugging

If pr approved, I will also apply on the admin and rebuild the 5.22.0 image

