### PR TITLE
Fix template scoping issue in gomplate Apache config

### DIFF
--- a/config/apache2/conf.d/elasticms.conf.gtpl
+++ b/config/apache2/conf.d/elasticms.conf.gtpl
@@ -63,16 +63,17 @@
 {{- if ne .Env.APACHE_ENVIRONMENTS "" }}
 
   {{- $environments := env.Getenv "APACHE_ENVIRONMENTS" | jsonArray -}}
+  {{- $globalContext := . -}}
   {{- range $env := $environments }}
 
-    Alias {{ $env.alias }}/bundles/emsch_assets {{ .Env.APP_SRC_DIR }}/public/bundles/{{ $env.env }}
-    Alias {{ $env.alias }} {{ .Env.APP_SRC_DIR }}/public
+    Alias {{ $env.alias }}/bundles/emsch_assets {{ $globalContext.Env.APP_SRC_DIR }}/public/bundles/{{ $env.env }}
+    Alias {{ $env.alias }} {{ $globalContext.Env.APP_SRC_DIR }}/public
 
     RewriteCond %{REQUEST_URI} !^{{ $env.alias }}/index.php
 
-    {{- if ne .Env.APACHE_CUSTOM_ASSETS_RC "" }}
+    {{- if ne $globalContext.Env.APACHE_CUSTOM_ASSETS_RC "" }}
 
-    RewriteCond %{REQUEST_URI} !^{{ .Env.APACHE_CUSTOM_ASSETS_RC }}
+    RewriteCond %{REQUEST_URI} !^{{ $globalContext.Env.APACHE_CUSTOM_ASSETS_RC }}
 
     {{ else }}
 


### PR DESCRIPTION
Fixes a scoping issue in the Apache configuration template using gomplate.

Previously, the environment variable `APP_SRC_DIR` could not be accessed inside the `range` loop due to context changes in gomplate. This caused the template rendering to fail with the error:

```
map has no entry for key "Env"
```

To resolve this, the global context is now stored in a separate variable ( `$globalContext` ) before the `range`, allowing safe access to `.Env` variables inside the loop.